### PR TITLE
Empty out the `url` and `baseurl` config values

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,9 @@ rss: RSS
 
 ### Build settings
 
-url: https://michaelcurrin.github.io
-baseurl: /jekyll-blog-demo
+# These will be automatically set by the GH Pages build
+url:
+baseurl:
 
 permalink: pretty
 


### PR DESCRIPTION
I'm not a Jekyll expert by any means, but the presence of values for the `url` and `baseurl` configuration properties in the `_config.yml` file prevented the GitHub Pages build from automatically setting these on my behalf (via [this section of the `jekyll-github-metadata` gem](https://github.com/jekyll/github-metadata/blob/e596203165b50fe0b3ad31ae59c40d1e301af33b/lib/jekyll-github-metadata/site_github_munger.rb#L48-L54)).

Emptying out the values did the trick for me. 🎉 